### PR TITLE
Fixes 100vw/% scrollbar overflow

### DIFF
--- a/web/components/sections/Hero.module.css
+++ b/web/components/sections/Hero.module.css
@@ -14,7 +14,7 @@
 }
 
 .content {
-  width: 100vw;
+  width: 100%;
   min-height: 100vh;
   padding: 0 1.5em;
   box-sizing: border-box;
@@ -30,7 +30,7 @@
   top: 0;
   overflow: hidden;
   display: block;
-  width: 100vw;
+  width: 100%;
   height: 100vh;
   object-fit: cover;
   opacity: 0;
@@ -43,7 +43,7 @@
   top: 0;
   overflow: hidden;
   display: block;
-  width: 100vw;
+  width: 100%;
   height: 100vh;
   object-fit: cover;
   z-index: -1;
@@ -55,7 +55,7 @@
   top: 0;
   overflow: hidden;
   display: block;
-  width: 100vw;
+  width: 100%;
   height: 100vh;
   object-fit: cover;
   opacity: 1;

--- a/web/components/sections/HomePage.module.css
+++ b/web/components/sections/HomePage.module.css
@@ -28,7 +28,7 @@
 }
 
 .content {
-  width: 100vw;
+  width: 100%;
   min-height: 100vh;
   padding: 0 1.5em;
   box-sizing: border-box;

--- a/web/components/sections/HomePageVideo.module.css
+++ b/web/components/sections/HomePageVideo.module.css
@@ -12,7 +12,7 @@
 }
 
 .wrapper iframe {
-  width: 100vw;
+  width: 100%;
   height: 56.25vw; /* Given a 16:9 aspect ratio, 9/16*100 = 56.25 */
   min-height: 100vh;
   min-width: 177.77vh; /* Given a 16:9 aspect ratio, 16/9*100 = 177.77 */

--- a/web/components/sections/LocationsImageGallery.module.css
+++ b/web/components/sections/LocationsImageGallery.module.css
@@ -5,7 +5,7 @@
   position: relative;
   padding: 2rem 0;
   height: 100vh;
-  width: 100vw;
+  width: 100%;
   z-index: 30;
   position: absolute;
   top: 0;

--- a/web/components/sections/Video.module.css
+++ b/web/components/sections/Video.module.css
@@ -12,7 +12,7 @@
 }
 
 .wrapper iframe {
-  width: 100vw;
+  width: 100%;
   height: 56.25vw; /* Given a 16:9 aspect ratio, 9/16*100 = 56.25 */
   min-height: 100vh;
   min-width: 177.77vh; /* Given a 16:9 aspect ratio, 16/9*100 = 177.77 */


### PR DESCRIPTION
Minor cross-browser fix for containers overflowing few pixels over the vertical scrollbar creating an unnecessary horizontal scrollbar.
Fixes issue in Windows and Linux browsers. 